### PR TITLE
Add VueUse, MDN, and Babylon.js documentation.

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -375,3 +375,4 @@
 { "name": "FusionAuth API", "crawlerStart": "https://fusionauth.io/docs/v1/tech/apis/", "crawlerPrefix": "https://fusionauth.io/docs/v1/tech/apis/" }
 { "name": "Serp Google Scholar API", "crawlerStart": "https://serpapi.com/google-scholar-api", "crawlerPrefix": "https://serpapi.com/google-scholar-api" }
 { "name": "MDN", "crawlerStart": "https://developer.mozilla.org/en-US/docs/", "crawlerPrefix": "https://developer.mozilla.org/en-US/docs/" }
+{ "name": "Babylon.js", "crawlerStart": "https://doc.babylonjs.com/", "crawlerPrefix": "https://doc.babylonjs.com/" }

--- a/docs.jsonl
+++ b/docs.jsonl
@@ -19,7 +19,8 @@
 { "name": "Transformers", "crawlerStart": "https://huggingface.co/docs/transformers/", "crawlerPrefix": "https://huggingface.co/docs/transformers/" }
 { "name": "Hugging-Face-Transformers", "crawlerStart": "https://huggingface.co/docs/transformers/", "crawlerPrefix": "https://huggingface.co/docs/transformers/" }
 { "name": "Langchain", "crawlerStart": "https://python.langchain.com/docs/", "crawlerPrefix": "https://python.langchain.com/docs/" }
-{ "name": "Vue", "crawlerStart": "https://vuejs.org/guide/", "crawlerPrefix": "https://vuejs.org/guide/" }
+{ "name": "Vue", "crawlerStart": "https://vuejs.org/guide/", "crawlerPrefix": "https://vuejs.org/guide/" },
+{ "name": "VueUse", "crawlerStart": "https://vueuse.org/", "crawlerPrefix": "https://vueuse.org/" }
 { "name": "Angular", "crawlerStart": "https://angular.io/docs", "crawlerPrefix": "https://angular.io/docs" }
 { "name": "Astro", "crawlerStart": "https://docs.astro.build/en/", "crawlerPrefix": "https://docs.astro.build/en/" }
 { "name": "Elixir", "crawlerStart": "https://elixir-lang.org/docs.html", "crawlerPrefix": "https://elixir-lang.org/docs.html" }
@@ -372,4 +373,5 @@
 { "name": "SQLFluff", "crawlerStart": "https://docs.sqlfluff.com/en/stable/", "crawlerPrefix": "https://docs.sqlfluff.com/en/stable/" }
 { "name": "Ruff", "crawlerStart": "https://beta.ruff.rs/docs/", "crawlerPrefix": "https://beta.ruff.rs/docs/" }
 { "name": "FusionAuth API", "crawlerStart": "https://fusionauth.io/docs/v1/tech/apis/", "crawlerPrefix": "https://fusionauth.io/docs/v1/tech/apis/" }
-{ "name": "Serp Google Scholar API", "crawlerStart": "https://serpapi.com/google-scholar-api", "crawlerPrefix": "https://serpapi.com/google-scholar-api" }
+{ "name": "Serp Google Scholar API", "crawlerStart": "https://serpapi.com/google-scholar-api", "crawlerPrefix": "https://serpapi.com/google-scholar-api" },
+{ "name": "MDN", "crawlerStart": "https://developer.mozilla.org/en-US/docs/", "crawlerPrefix": "https://developer.mozilla.org/en-US/docs/" },

--- a/docs.jsonl
+++ b/docs.jsonl
@@ -19,7 +19,7 @@
 { "name": "Transformers", "crawlerStart": "https://huggingface.co/docs/transformers/", "crawlerPrefix": "https://huggingface.co/docs/transformers/" }
 { "name": "Hugging-Face-Transformers", "crawlerStart": "https://huggingface.co/docs/transformers/", "crawlerPrefix": "https://huggingface.co/docs/transformers/" }
 { "name": "Langchain", "crawlerStart": "https://python.langchain.com/docs/", "crawlerPrefix": "https://python.langchain.com/docs/" }
-{ "name": "Vue", "crawlerStart": "https://vuejs.org/guide/", "crawlerPrefix": "https://vuejs.org/guide/" },
+{ "name": "Vue", "crawlerStart": "https://vuejs.org/guide/", "crawlerPrefix": "https://vuejs.org/guide/" }
 { "name": "VueUse", "crawlerStart": "https://vueuse.org/", "crawlerPrefix": "https://vueuse.org/" }
 { "name": "Angular", "crawlerStart": "https://angular.io/docs", "crawlerPrefix": "https://angular.io/docs" }
 { "name": "Astro", "crawlerStart": "https://docs.astro.build/en/", "crawlerPrefix": "https://docs.astro.build/en/" }
@@ -373,5 +373,5 @@
 { "name": "SQLFluff", "crawlerStart": "https://docs.sqlfluff.com/en/stable/", "crawlerPrefix": "https://docs.sqlfluff.com/en/stable/" }
 { "name": "Ruff", "crawlerStart": "https://beta.ruff.rs/docs/", "crawlerPrefix": "https://beta.ruff.rs/docs/" }
 { "name": "FusionAuth API", "crawlerStart": "https://fusionauth.io/docs/v1/tech/apis/", "crawlerPrefix": "https://fusionauth.io/docs/v1/tech/apis/" }
-{ "name": "Serp Google Scholar API", "crawlerStart": "https://serpapi.com/google-scholar-api", "crawlerPrefix": "https://serpapi.com/google-scholar-api" },
-{ "name": "MDN", "crawlerStart": "https://developer.mozilla.org/en-US/docs/", "crawlerPrefix": "https://developer.mozilla.org/en-US/docs/" },
+{ "name": "Serp Google Scholar API", "crawlerStart": "https://serpapi.com/google-scholar-api", "crawlerPrefix": "https://serpapi.com/google-scholar-api" }
+{ "name": "MDN", "crawlerStart": "https://developer.mozilla.org/en-US/docs/", "crawlerPrefix": "https://developer.mozilla.org/en-US/docs/" }


### PR DESCRIPTION
VueUse has an odd structure so I had to put the root site to be crawled since other parts of the docs won't get caught otherwise.