### PR TITLE
Add Shiny docs

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -376,3 +376,5 @@
 { "name": "Serp Google Scholar API", "crawlerStart": "https://serpapi.com/google-scholar-api", "crawlerPrefix": "https://serpapi.com/google-scholar-api" }
 { "name": "Novu", "crawlerStart": "https://docs.novu.co/", "crawlerPrefix": "https://docs.novu.co/" }
 { "name": "Drizzle", "crawlerStart": "https://orm.drizzle.team/docs/overview", "crawlerPrefix": "https://orm.drizzle.team/docs/overview" }
+{ "name": "Shiny-R", "crawlerStart": "https://shiny.posit.co/r/", "crawlerPrefix": "https://shiny.posit.co/r/" }
+{ "name": "Shiny-Py", "crawlerStart": "https://shiny.posit.co/py/", "crawlerPrefix": "https://shiny.posit.co/py/" }


### PR DESCRIPTION
This adds documentation for Shiny, which is a reactive web application framework with clients in R and Python. 

https://shiny.posit.co/py/