### PR TITLE
Update Stripe API Reference URL

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -2,7 +2,7 @@
 { "name": "React", "crawlerStart": "https://react.dev/reference/", "crawlerPrefix": "https://react.dev/reference/" }
 { "name": "Tailwind CSS", "crawlerStart": "https://tailwindcss.com/docs/", "crawlerPrefix": "https://tailwindcss.com/docs/" }
 { "name": "Qwik", "crawlerStart": "https://qwik.builder.io/docs/", "crawlerPrefix": "https://qwik.builder.io/docs/" }
-{ "name": "Stripe", "crawlerStart": "https://stripe.com/docs/api", "crawlerPrefix": "https://stripe.com/docs/api" }
+{ "name": "Stripe", "crawlerStart": "https://docs.stripe.com/api", "crawlerPrefix": "https://docs.stripe.com/api" }
 { "name": "PostHog", "crawlerStart": "https://posthog.com/docs", "crawlerPrefix": "https://posthog.com/docs" }
 { "name": "Express", "crawlerStart": "https://expressjs.com/en/5x/api.html", "crawlerPrefix": "https://expressjs.com/en/5x/" }
 { "name": "Boto3", "crawlerStart": "https://boto3.amazonaws.com/v1/documentation/api/latest/index.html", "crawlerPrefix": "https://boto3.amazonaws.com/v1/documentation/api/latest/" }


### PR DESCRIPTION
Stripe Docs moved domains, the old URL redirects, but this is better for the long term.