### PR TITLE
Add Descope Documentation

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -383,3 +383,4 @@
 { "name": "TLDraw", "crawlerStart": "https://tldraw.dev/", "crawlerPrefix": "https://tldraw.dev/" }
 { "name": "Swift", "crawlerStart": "https://developer.apple.com/documentation/technologies", "crawlerPrefix": "https://developer.apple.com/documentation/technologies" }
 { "name": "Solidity", "crawlerStart": "https://docs.soliditylang.org/", "crawlerPrefix": "https://docs.soliditylang.org/" }
+{ "name": "Descope", "crawlerStart": "https://docs.descope.com/", "crawlerPrefix": "https://docs.descope.com/" }


### PR DESCRIPTION
Add a new entry for Descope documentation to docs.jsonl.

Add the entry { "name": "Descope", "crawlerStart": "https://docs.descope.com/", "crawlerPrefix": "https://docs.descope.com/" } to the end of the file.