### PR TITLE
feat(docs): add uniapp documentation

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -383,3 +383,4 @@
 { "name": "TLDraw", "crawlerStart": "https://tldraw.dev/", "crawlerPrefix": "https://tldraw.dev/" }
 { "name": "Swift", "crawlerStart": "https://developer.apple.com/documentation/technologies", "crawlerPrefix": "https://developer.apple.com/documentation/technologies" }
 { "name": "Solidity", "crawlerStart": "https://docs.soliditylang.org/", "crawlerPrefix": "https://docs.soliditylang.org/" }
+{ "name": "uniapp", "crawlerStart": "https://uniapp.dcloud.io/", "crawlerPrefix": "https://uniapp.dcloud.io/" }


### PR DESCRIPTION
Added documentation entry for uniapp with crawlerStart and crawlerPrefix URLs.