### PR TITLE
feat(docs): add uniapp and WeChat Mini Program documentation

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -383,3 +383,4 @@
 { "name": "TLDraw", "crawlerStart": "https://tldraw.dev/", "crawlerPrefix": "https://tldraw.dev/" }
 { "name": "Swift", "crawlerStart": "https://developer.apple.com/documentation/technologies", "crawlerPrefix": "https://developer.apple.com/documentation/technologies" }
 { "name": "Solidity", "crawlerStart": "https://docs.soliditylang.org/", "crawlerPrefix": "https://docs.soliditylang.org/" }
+{ "name": "WeChat Mini Program", "crawlerStart": "https://developers.weixin.qq.com/miniprogram/en/dev/framework/", "crawlerPrefix": "https://developers.weixin.qq.com/miniprogram/en/dev/" }


### PR DESCRIPTION
Added documentation entries for uniapp and WeChat Mini Program with crawlerStart and crawlerPrefix URLs.