### PR TITLE
Add docs for Clerk, Drizzle, and shadcn/ui

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -383,3 +383,6 @@
 { "name": "TLDraw", "crawlerStart": "https://tldraw.dev/", "crawlerPrefix": "https://tldraw.dev/" }
 { "name": "Swift", "crawlerStart": "https://developer.apple.com/documentation/technologies", "crawlerPrefix": "https://developer.apple.com/documentation/technologies" }
 { "name": "Solidity", "crawlerStart": "https://docs.soliditylang.org/", "crawlerPrefix": "https://docs.soliditylang.org/" }
+{ "name": "Clerk", "crawlerStart": "https://clerk.com/docs/", "crawlerPrefix": "https://clerk.com/docs/" }
+{ "name": "shadcn/ui", "crawlerStart": "https://ui.shadcn.com/docs/", "crawlerPrefix": "https://ui.shadcn.com/docs/" }
+{ "name": "Drizzle", "crawlerStart": "https://orm.drizzle.team/docs/overview", "crawlerPrefix": "https://orm.drizzle.team/docs/" }


### PR DESCRIPTION
Let me know if you need these pulled apart into separate PRs.

The Clerk docs are a bit tricky because it has a ton of languages and frameworks support in the docs so that might get confused the context. Wasn't sure the best way to solve this and if there is a way to limit the docs to just the language / framework the user cares about.