### PR TITLE
Add Clever Tools CLI

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -383,3 +383,5 @@
 { "name": "TLDraw", "crawlerStart": "https://tldraw.dev/", "crawlerPrefix": "https://tldraw.dev/" }
 { "name": "Swift", "crawlerStart": "https://developer.apple.com/documentation/technologies", "crawlerPrefix": "https://developer.apple.com/documentation/technologies" }
 { "name": "Solidity", "crawlerStart": "https://docs.soliditylang.org/", "crawlerPrefix": "https://docs.soliditylang.org/" }
+{ "name": "Clever Cloud CLI", "crawlerStart": "https://github.com/CleverCloud/clever-tools/blob/master/docs/README.md", "crawlerPrefix": "https://github.com/CleverCloud/clever-tools/tree/master/docs" }
+


### PR DESCRIPTION
This PR adds Clever Cloud CLI (Clever Tools) to allow users to get contexte about how to deploy and manage ressources on our platform