### PR TITLE
Update HubSpot documentation symbol and point to LLM focused docs

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -222,7 +222,7 @@
 { "name": "Pubnub", "crawlerStart": "https://www.pubnub.com/docs", "crawlerPrefix": "https://www.pubnub.com/docs" }
 { "name": "Twilio", "crawlerStart": "https://www.twilio.com/docs/quickstart", "crawlerPrefix": "https://www.twilio.com/docs/" }
 { "name": "Bandwidth", "crawlerStart": "https://dev.bandwidth.com/docs/", "crawlerPrefix": "https://dev.bandwidth.com/docs/" }
-{ "name": "HubSpot Operations Hub", "crawlerStart": "https://developers.hubspot.com/docs/api/overview", "crawlerPrefix": "https://developers.hubspot.com/docs/api/" }
+{ "name": "HubSpot", "crawlerStart": "https://developers.hubspot.com/docs/llms-full.txt", "crawlerPrefix": "https://developers.hubspot.com/docs/llms-full.txt" }
 { "name": "Podium", "crawlerStart": "https://docs.podium.com/docs", "crawlerPrefix": "https://docs.podium.com/" }
 { "name": "Whereby", "crawlerStart": "https://docs.whereby.com//", "crawlerPrefix": "https://docs.whereby.com/" }
 { "name": "Plivo", "crawlerStart": "https://www.plivo.com/docs/", "crawlerPrefix": "https://www.plivo.com/docs/" }


### PR DESCRIPTION
Hey there, HubSpot Employee here.

I made an update to the reference to the HubSpot docs, pointing to our llm focused version of our docs and fixing the naming of the docs symbol.

This should improve the experience of using cursor with HubSpot and the LLM version of the docs should make the quality of the results better and more responsive.

Let me know if you need any tweaks happy to make em.

Thanks team.