### PR TITLE
Add Neo4j to docs

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -83,6 +83,7 @@
 {  "name": "MongoDB",  "crawlerStart": "https://www.mongodb.com/docs/manual/",  "crawlerPrefix": "https://www.mongodb.com/docs/manual/"}
 {  "name": "MySQL",  "crawlerStart": "https://dev.mysql.com/doc/",  "crawlerPrefix": "https://dev.mysql.com/doc/"}
 {  "name": "NLTK",  "crawlerStart": "https://www.nltk.org/",  "crawlerPrefix": "https://www.nltk.org/"}
+{  "name": "Neo4j",  "crawlerStart": "https://neo4j.com/docs/",  "crawlerPrefix": "https://neo4j.com/docs/"}
 {  "name": "NestJS",  "crawlerStart": "https://docs.nestjs.com/",  "crawlerPrefix": "https://docs.nestjs.com/"}
 {  "name": "Netlify",  "crawlerStart": "https://docs.netlify.com/",  "crawlerPrefix": "https://docs.netlify.com/"}
 {  "name": "NextJS",  "crawlerStart": "https://nextjs.org/docs",  "crawlerPrefix": "https://nextjs.org/docs"}


### PR DESCRIPTION
> A comment explaining what you're adding/fixing and why

This PR adds docs source for Neo4j. I'm requesting adding docs for Neo4j because it's a popular graph DBMS for [many enterprise customers](https://neo4j.com/who-uses-neo4j/) like Adobe, eBay, etc. -- Having access to Neo4j docs inside Cursor would allow developers at these companies to be more productive.

> Confirmation that you've run the reorder script

Yes
![](https://github.com/user-attachments/assets/6b9fdae8-16a7-404a-bc13-18f9ef15ceaf)