### PR TITLE
Add AG Grid React to docs

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -1,3 +1,4 @@
+{  "name": "AG Grid React",  "crawlerStart": "https://www.ag-grid.com/react-data-grid/",  "crawlerPrefix": "https://www.ag-grid.com/react-data-grid/"}
 {  "name": "ASP.NET",  "crawlerStart": "https://learn.microsoft.com/en-us/aspnet/core/?view=aspnetcore-7.0",  "crawlerPrefix": "https://learn.microsoft.com/en-us/aspnet/core/"}
 {  "name": "AWS Amplify",  "crawlerStart": "https://docs.amplify.aws/",  "crawlerPrefix": "https://docs.amplify.aws/"}
 {  "name": "AWS CLI",  "crawlerStart": "https://docs.aws.amazon.com/cli/latest/reference/",  "crawlerPrefix": "https://docs.aws.amazon.com/cli/latest/reference/"}


### PR DESCRIPTION
> A comment explaining what you're adding/fixing and why

This PR adds docs source for AG Grid for React. I'm requesting adding docs for AG Grid because it's a [popular](https://github.com/ag-grid/ag-grid) open-source, enterprise solution for creating data tables. Its docs are complex, so having these docs readily available out of the box for developers would be a tremendous productivity boost.

> Confirmation that you've run the reorder script

Yes
![](https://github.com/user-attachments/assets/6b9fdae8-16a7-404a-bc13-18f9ef15ceaf)