### PR TITLE
Add Nylas APIs to dropdown options

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -91,6 +91,7 @@
 {  "name": "Notion",  "crawlerStart": "https://developers.notion.com/reference/",  "crawlerPrefix": "https://developers.notion.com/reference/"}
 {  "name": "NumPy",  "crawlerStart": "https://numpy.org/doc/stable/",  "crawlerPrefix": "https://numpy.org/doc/stable/"}
 {  "name": "Nuxt",  "crawlerStart": "https://nuxt.com/docs",  "crawlerPrefix": "https://nuxt.com/docs"}
+{  "name": "Nylas",  "crawlerStart": "http://developer.nylas.com",  "crawlerPrefix": "http://developer.nylas.com"}
 {  "name": "OpenAI",  "crawlerStart": "https://platform.openai.com/docs/",  "crawlerPrefix": "https://platform.openai.com/docs/"}
 {  "name": "OpenCV",  "crawlerStart": "https://docs.opencv.org/4.x/",  "crawlerPrefix": "https://docs.opencv.org/4.x/"}
 {  "name": "PHP",  "crawlerStart": "https://www.php.net/manual/en/",  "crawlerPrefix": "https://www.php.net/manual/en/"}


### PR DESCRIPTION
Hi, re-creating PR to address concerns of last PR (#86)

1. Adding [Nylas](http://developer.nylas.com/) to Cursor crawler dropdown
  - Nylas APIs are developer specific used directly by developers in their workflow
2. Reorder script was run:
<img width="381" alt="Screenshot 2025-02-16 at 3 38 26 PM" src="https://github.com/user-attachments/assets/4777747d-dd4b-41b2-a377-a2701dc03a47" />


I've read the updated README.md, and if I missed anything, please advise, happy to address.


