### PR TITLE
Added Ruby documentation

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -108,6 +108,7 @@
 {  "name": "Redis",  "crawlerStart": "https://redis.io/docs/",  "crawlerPrefix": "https://redis.io/docs/"}
 {  "name": "Regex",  "crawlerStart": "https://www.regular-expressions.info/",  "crawlerPrefix": "https://www.regular-expressions.info/"}
 {  "name": "Remix",  "crawlerStart": "https://remix.run/docs/en/main",  "crawlerPrefix": "https://remix.run/docs/"}
+{  "name": "Ruby",  "crawlerStart": "https://docs.ruby-lang.org/en/master/", "crawlerPrefix": "https://docs.ruby-lang.org/en/" }
 {  "name": "Rust",  "crawlerStart": "https://doc.rust-lang.org/book/",  "crawlerPrefix": "https://doc.rust-lang.org/book/"}
 {  "name": "Rust Stdlib",  "crawlerStart": "https://doc.rust-lang.org/std/",  "crawlerPrefix": "https://doc.rust-lang.org/std/"}
 {  "name": "SQLite",  "crawlerStart": "https://www.sqlite.org/docs.html",  "crawlerPrefix": "https://www.sqlite.org/"}


### PR DESCRIPTION
Added [Ruby language documentation](https://docs.ruby-lang.org/en/master/) to the crawler. 

I have checked [the guideline](https://github.com/getcursor/crawler/blob/main/README.md). 

