### PR TITLE
Add smolagents docs by Hugging Face after reordering

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -114,6 +114,7 @@
 {  "name": "Scikit-learn",  "crawlerStart": "https://scikit-learn.org/stable/",  "crawlerPrefix": "https://scikit-learn.org/stable/"}
 {  "name": "Selenium",  "crawlerStart": "https://www.selenium.dev/documentation/",  "crawlerPrefix": "https://www.selenium.dev/documentation/"}
 {  "name": "Sentry",  "crawlerStart": "https://docs.sentry.io/",  "crawlerPrefix": "https://docs.sentry.io/"}
+{  "name": "Smolagents",  "crawlerStart": "https://huggingface.co/docs/smolagents/en/index",  "crawlerPrefix": "https://huggingface.co/docs/smolagents/en/"}
 {  "name": "Socket.io",  "crawlerStart": "https://socket.io/docs/v4/",  "crawlerPrefix": "https://socket.io/docs/v4/"}
 {  "name": "Solidity",  "crawlerStart": "https://docs.soliditylang.org/en/latest/",  "crawlerPrefix": "https://docs.soliditylang.org/en/latest/"}
 {  "name": "Spring",  "crawlerStart": "https://docs.spring.io/spring-framework/reference/",  "crawlerPrefix": "https://docs.spring.io/spring-framework/reference/"}


### PR DESCRIPTION
Smolagents is a lightweight framework for building powerful agent systems and its documentation is hosted on Hugging Face at:
  - Starting URL: https://huggingface.co/docs/smolagents
  - Prefix URL: https://huggingface.co/docs/smolagents

This new entry meets all our guidelines:
  - Widely Used: Smolagents is recognized in the community and frequently compared with Langgraph, crewai, etc. Also this: https://huggingface.co/papers/2402.01030
  - Well-Documented: It has comprehensive, maintained documentation.
  - Developer-Focused
  - Documentation is in English and represents the latest stable docs.

I have added only one new entry to `docs.jsonl` and have run the reorder script (`./scripts/reorder.sh`) as specified in the guidelines.

Thanks!