### PR TITLE
Add Clever Tools CLI

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -23,6 +23,7 @@
 {  "name": "Cheerio",  "crawlerStart": "https://cheerio.js.org/docs/intro",  "crawlerPrefix": "https://cheerio.js.org/docs/"}
 {  "name": "CircleCI",  "crawlerStart": "https://circleci.com/docs/",  "crawlerPrefix": "https://circleci.com/docs/"}
 {  "name": "Clerk",  "crawlerStart": "https://clerk.com/docs",  "crawlerPrefix": "https://clerk.com/docs"}
+{  "name": "Clever Cloud CLI",  "crawlerStart": "https://github.com/CleverCloud/clever-tools/blob/master/docs/README.md",  "crawlerPrefix": "https://github.com/CleverCloud/clever-tools/tree/master/docs"}
 {  "name": "Cloudflare",  "crawlerStart": "https://developers.cloudflare.com/",  "crawlerPrefix": "https://developers.cloudflare.com/"}
 {  "name": "CodeMirror",  "crawlerStart": "https://codemirror.net/docs/",  "crawlerPrefix": "https://codemirror.net/docs/"}
 {  "name": "Cursor",  "crawlerStart": "https://docs.cursor.com/",  "crawlerPrefix": "https://docs.cursor.com/"}


### PR DESCRIPTION
This PR adds Clever Cloud CLI (Clever Tools) to allow users to get contexte about how to deploy and manage ressources on our platform