### PR TITLE
Add assistant-ui

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -1,4 +1,5 @@
 {  "name": "ASP.NET",  "crawlerStart": "https://learn.microsoft.com/en-us/aspnet/core/?view=aspnetcore-7.0",  "crawlerPrefix": "https://learn.microsoft.com/en-us/aspnet/core/"}
+{  "name": "assistant-ui",  "crawlerStart": "https://www.assistant-ui.com/docs/getting-started",  "crawlerPrefix": "https://www.assistant-ui.com/docs/"}
 {  "name": "AWS Amplify",  "crawlerStart": "https://docs.amplify.aws/",  "crawlerPrefix": "https://docs.amplify.aws/"}
 {  "name": "AWS CLI",  "crawlerStart": "https://docs.aws.amazon.com/cli/latest/reference/",  "crawlerPrefix": "https://docs.aws.amazon.com/cli/latest/reference/"}
 {  "name": "AWS DynamoDB",  "crawlerStart": "https://docs.aws.amazon.com/dynamodb/",  "crawlerPrefix": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/"}


### PR DESCRIPTION
assistant-ui is a typescript/react library for chatbot UIs. It's the most downloaded npm package in this catergory (>50k monthly npm downloads).

- [x] Read the eligibility criteria
- [x] Ran reorder script

I'm adding this to cursor as several of my users have asked for this feature.

Company: https://ycombinator.com/companies/assistant-ui
Docs: https://www.assistant-ui.com/docs/getting-started