### PR TITLE
Add Mantine (React component library)

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -77,6 +77,7 @@
 {  "name": "Laravel",  "crawlerStart": "https://laravel.com/docs/10.x",  "crawlerPrefix": "https://laravel.com/docs/10.x"}
 {  "name": "Linux Man Pages",  "crawlerStart": "https://man7.org/linux/man-pages/dir_all_alphabetic.html",  "crawlerPrefix": "https://man7.org/linux/man-pages/"}
 {  "name": "MLX",  "crawlerStart": "https://ml-explore.github.io/mlx/build/html/",  "crawlerPrefix": "https://ml-explore.github.io/mlx/build/html/"}
+{  "name": "Mantine",  "crawlerStart": "https://mantine.dev/overview/",  "crawlerPrefix": "https://mantine.dev/overview/"}
 {  "name": "Material UI",  "crawlerStart": "https://mui.com/material-ui/getting-started/",  "crawlerPrefix": "https://mui.com/material-ui/"}
 {  "name": "Matplotlib",  "crawlerStart": "https://matplotlib.org/stable/api/",  "crawlerPrefix": "https://matplotlib.org/stable/api/"}
 {  "name": "Maven",  "crawlerStart": "https://maven.apache.org/guides/",  "crawlerPrefix": "https://maven.apache.org/guides/"}

--- a/docs.jsonl
+++ b/docs.jsonl
@@ -112,7 +112,7 @@
 {  "name": "Redis",  "crawlerStart": "https://redis.io/docs/",  "crawlerPrefix": "https://redis.io/docs/"}
 {  "name": "Regex",  "crawlerStart": "https://www.regular-expressions.info/",  "crawlerPrefix": "https://www.regular-expressions.info/"}
 {  "name": "Remix",  "crawlerStart": "https://remix.run/docs/en/main",  "crawlerPrefix": "https://remix.run/docs/"}
-{  "name": "Ruby",  "crawlerStart": "https://docs.ruby-lang.org/en/master/", "crawlerPrefix": "https://docs.ruby-lang.org/en/" }
+{  "name": "Ruby",  "crawlerStart": "https://docs.ruby-lang.org/en/master/",  "crawlerPrefix": "https://docs.ruby-lang.org/en/"}
 {  "name": "Rust",  "crawlerStart": "https://doc.rust-lang.org/book/",  "crawlerPrefix": "https://doc.rust-lang.org/book/"}
 {  "name": "Rust Stdlib",  "crawlerStart": "https://doc.rust-lang.org/std/",  "crawlerPrefix": "https://doc.rust-lang.org/std/"}
 {  "name": "SQLite",  "crawlerStart": "https://www.sqlite.org/docs.html",  "crawlerPrefix": "https://www.sqlite.org/"}


### PR DESCRIPTION
Hey Cursor team 👋  I'm adding [Mantine](https://github.com/mantinedev/mantine), a pretty popular and actively maintained React component library (27k GH stars) to the docs list.

I checked [the guideline](https://github.com/getcursor/crawler/blob/main/README.md) and ran the reorder script.