### PR TITLE
Add Farcaster to crawler

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -45,6 +45,7 @@
 {  "name": "Express",  "crawlerStart": "https://expressjs.com/en/5x/api.html",  "crawlerPrefix": "https://expressjs.com/en/5x/"}
 {  "name": "FFmpeg",  "crawlerStart": "https://ffmpeg.org/ffmpeg.html",  "crawlerPrefix": "https://ffmpeg.org/ffmpeg.html"}
 {  "name": "Fabric.js",  "crawlerStart": "http://fabricjs.com/docs/",  "crawlerPrefix": "http://fabricjs.com/docs/"}
+{  "name": "Farcaster",  "crawlerStart": "https://docs.farcaster.xyz",  "crawlerPrefix": "https://docs.farcaster.xyz"}
 {  "name": "FastAPI",  "crawlerStart": "https://fastapi.tiangolo.com/tutorial/",  "crawlerPrefix": "https://fastapi.tiangolo.com/tutorial/"}
 {  "name": "Firebase",  "crawlerStart": "https://firebase.google.com/docs",  "crawlerPrefix": "https://firebase.google.com/docs"}
 {  "name": "Flask",  "crawlerStart": "https://flask.palletsprojects.com/en/2.3.x/",  "crawlerPrefix": "https://flask.palletsprojects.com/en/2.3.x/"}
@@ -111,7 +112,7 @@
 {  "name": "Redis",  "crawlerStart": "https://redis.io/docs/",  "crawlerPrefix": "https://redis.io/docs/"}
 {  "name": "Regex",  "crawlerStart": "https://www.regular-expressions.info/",  "crawlerPrefix": "https://www.regular-expressions.info/"}
 {  "name": "Remix",  "crawlerStart": "https://remix.run/docs/en/main",  "crawlerPrefix": "https://remix.run/docs/"}
-{  "name": "Ruby",  "crawlerStart": "https://docs.ruby-lang.org/en/master/", "crawlerPrefix": "https://docs.ruby-lang.org/en/" }
+{  "name": "Ruby",  "crawlerStart": "https://docs.ruby-lang.org/en/master/",  "crawlerPrefix": "https://docs.ruby-lang.org/en/"}
 {  "name": "Rust",  "crawlerStart": "https://doc.rust-lang.org/book/",  "crawlerPrefix": "https://doc.rust-lang.org/book/"}
 {  "name": "Rust Stdlib",  "crawlerStart": "https://doc.rust-lang.org/std/",  "crawlerPrefix": "https://doc.rust-lang.org/std/"}
 {  "name": "SQLite",  "crawlerStart": "https://www.sqlite.org/docs.html",  "crawlerPrefix": "https://www.sqlite.org/"}


### PR DESCRIPTION
[Farcaster](https://farcaster.xyz) is an open decentralized social protocol with 800k+ users and a thriving developer ecosystem.

- [x] Run the re-order script