### PR TITLE
Add Bun documentation links to docs.jsonl

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -18,6 +18,7 @@
 {  "name": "Bash",  "crawlerStart": "https://www.gnu.org/software/bash/manual/bash.html",  "crawlerPrefix": "https://www.gnu.org/software/bash/manual/"}
 {  "name": "BeautifulSoup",  "crawlerStart": "https://www.crummy.com/software/BeautifulSoup/bs4/doc/",  "crawlerPrefix": "https://www.crummy.com/software/BeautifulSoup/bs4/doc/"}
 {  "name": "Boto3",  "crawlerStart": "https://boto3.amazonaws.com/v1/documentation/api/latest/index.html",  "crawlerPrefix": "https://boto3.amazonaws.com/v1/documentation/api/latest/"}
+{  "name": "Bun",  "crawlerStart": "https://bun.sh/docs",  "crawlerPrefix": "https://bun.sh/docs"}
 {  "name": "C#",  "crawlerStart": "https://learn.microsoft.com/en-us/dotnet/csharp/",  "crawlerPrefix": "https://learn.microsoft.com/en-us/dotnet/csharp/"}
 {  "name": "CSS",  "crawlerStart": "https://developer.mozilla.org/en-US/docs/Web/CSS",  "crawlerPrefix": "https://developer.mozilla.org/en-US/docs/Web/CSS"}
 {  "name": "Cheerio",  "crawlerStart": "https://cheerio.js.org/docs/intro",  "crawlerPrefix": "https://cheerio.js.org/docs/"}


### PR DESCRIPTION
Include links to Bun documentation in the docs.jsonl.

- [x]  Ran the re-order script.
- [x] Ran the test script.

![image](https://github.com/user-attachments/assets/c4add637-3c79-4e84-8233-89261236d276)
