### PR TITLE
Add Beanie ODM documentation source to docs.jsonl

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -136,3 +136,4 @@
 {  "name": "Vue",  "crawlerStart": "https://vuejs.org/guide/introduction.html",  "crawlerPrefix": "https://vuejs.org/guide/"}
 {  "name": "Webpack",  "crawlerStart": "https://webpack.js.org/concepts/",  "crawlerPrefix": "https://webpack.js.org/concepts/"}
 {  "name": "Zsh",  "crawlerStart": "https://zsh.sourceforge.io/Doc/",  "crawlerPrefix": "https://zsh.sourceforge.io/Doc/"}
+{  "name": "Beanie ODM",  "crawlerStart": "https://beanie-odm.dev/",  "crawlerPrefix": "https://beanie-odm.dev/"}


### PR DESCRIPTION
Include Beanie ODM in the documentation sources for better accessibility and reference.