### PR TITLE
Add Renovate docs

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -114,6 +114,7 @@
 {  "name": "Redis",  "crawlerStart": "https://redis.io/docs/",  "crawlerPrefix": "https://redis.io/docs/"}
 {  "name": "Regex",  "crawlerStart": "https://www.regular-expressions.info/",  "crawlerPrefix": "https://www.regular-expressions.info/"}
 {  "name": "Remix",  "crawlerStart": "https://remix.run/docs/en/main",  "crawlerPrefix": "https://remix.run/docs/"}
+{  "name": "Renovate",  "crawlerStart": "https://docs.renovatebot.com/",  "crawlerPrefix": "https://docs.renovatebot.com/"}
 {  "name": "Ruby",  "crawlerStart": "https://docs.ruby-lang.org/en/master/",  "crawlerPrefix": "https://docs.ruby-lang.org/en/"}
 {  "name": "Rust",  "crawlerStart": "https://doc.rust-lang.org/book/",  "crawlerPrefix": "https://doc.rust-lang.org/book/"}
 {  "name": "Rust Stdlib",  "crawlerStart": "https://doc.rust-lang.org/std/",  "crawlerPrefix": "https://doc.rust-lang.org/std/"}


### PR DESCRIPTION
Renovate is a dependency upgrade tool used very widely in the developer community. Renovate has massive number of [configuration options](https://docs.renovatebot.com/configuration-options/) available for developers to customize their upgrade workflows.

Vanilla LLMs are not good at explaining or changing the settings of the tool, so this will hopefully be a step in the right direction.

I've executed the reorder and test scripts.