### PR TITLE
Add Apple Developer Documentation source

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -12,6 +12,7 @@
 {  "name": "Ansible",  "crawlerStart": "https://docs.ansible.com/ansible/latest/index.html",  "crawlerPrefix": "https://docs.ansible.com/ansible/latest/"}
 {  "name": "Ant Design",  "crawlerStart": "https://ant.design/docs/react/introduce",  "crawlerPrefix": "https://ant.design/docs/react/"}
 {  "name": "Apollo GraphQL",  "crawlerStart": "https://www.apollographql.com/docs/",  "crawlerPrefix": "https://www.apollographql.com/docs/"}
+{  "name": "Apple Developer Documention",  "crawlerStart": "https://developer.apple.com/documentation/",  "crawlerPrefix": "https://developer.apple.com/documentation/"}
 {  "name": "Astro",  "crawlerStart": "https://docs.astro.build/en/",  "crawlerPrefix": "https://docs.astro.build/en/"}
 {  "name": "Auth0",  "crawlerStart": "https://auth0.com/docs",  "crawlerPrefix": "https://auth0.com/docs"}
 {  "name": "Azure Pipelines",  "crawlerStart": "https://docs.microsoft.com/en-us/azure/devops/pipelines/?view=azure-devops",  "crawlerPrefix": "https://docs.microsoft.com/en-us/azure/devops/pipelines/"}


### PR DESCRIPTION
This PR adds official Apple Developer Documentation to enhance the model's capabilities in Apple ecosystem development. The documentation meets all the required criteria for built-in docs as it is widely used, well-documented, developer-focused, and production-ready.

https://developer.apple.com/documentation/

![SCR-20250228-ixym](https://github.com/user-attachments/assets/d54e4748-c8f4-40da-942f-2dd6e0c6350d)


## Benefits:
- Improves accuracy and timeliness of Apple API references
- Enhances the model's Swift and SwiftUI coding capabilities
- Provides up-to-date documentation for Apple platform development
- Supports developers working in the Apple ecosystem with more precise assistance

## Implementation Details

- [x] Added documentation source following repository guidelines
- [x] Ran the reorder script to maintain proper organization