### PR TITLE
Add Vitest Docs

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -137,6 +137,7 @@
 {  "name": "Vercel",  "crawlerStart": "https://vercel.com/docs",  "crawlerPrefix": "https://vercel.com/docs"}
 {  "name": "Vim",  "crawlerStart": "https://vimhelp.org/",  "crawlerPrefix": "https://vimhelp.org/"}
 {  "name": "Vite",  "crawlerStart": "https://vitejs.dev/guide/",  "crawlerPrefix": "https://vitejs.dev/guide/"}
+{  "name": "Vitest",  "crawlerStart": "https://vitest.dev/guide/",  "crawlerPrefix": "https://vitest.dev/guide/"}
 {  "name": "Vue",  "crawlerStart": "https://vuejs.org/guide/introduction.html",  "crawlerPrefix": "https://vuejs.org/guide/"}
 {  "name": "Webpack",  "crawlerStart": "https://webpack.js.org/concepts/",  "crawlerPrefix": "https://webpack.js.org/concepts/"}
 {  "name": "Zsh",  "crawlerStart": "https://zsh.sourceforge.io/Doc/",  "crawlerPrefix": "https://zsh.sourceforge.io/Doc/"}


### PR DESCRIPTION
### A comment explaining what you're adding/fixing and why

https://github.com/getcursor/crawler/pull/40 was closed, I'm submitting a new one.
I think Vitest is a widely used and well documented testing framework.

### Confirmation that you've run the reorder script

- [x] Ran the re-order script.
- [x] Ran the test script.

<img width="401" alt="image" src="https://github.com/user-attachments/assets/afb327ff-ee49-4d29-9848-30cb276ddd1d" />
<br/>
<img width="386" alt="image" src="https://github.com/user-attachments/assets/4b970017-bb04-4489-8946-70a962dd5641" />
