### PR TITLE
Add Symfony framework(PHP) to docs

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -131,6 +131,7 @@
 {  "name": "Stripe",  "crawlerStart": "https://stripe.com/docs",  "crawlerPrefix": "https://stripe.com/docs"}
 {  "name": "Supabase",  "crawlerStart": "https://supabase.com/docs",  "crawlerPrefix": "https://supabase.com/docs"}
 {  "name": "Svelte",  "crawlerStart": "https://svelte.dev/docs",  "crawlerPrefix": "https://svelte.dev/docs"}
+{  "name": "Symfony",  "crawlerStart": "https://symfony.com/doc/current/",  "crawlerPrefix": "https://symfony.com/doc/"}
 {  "name": "Tailwind",  "crawlerStart": "https://tailwindcss.com/docs",  "crawlerPrefix": "https://tailwindcss.com/docs"}
 {  "name": "Terraform",  "crawlerStart": "https://developer.hashicorp.com/terraform/docs",  "crawlerPrefix": "https://developer.hashicorp.com/terraform/docs"}
 {  "name": "Three.js",  "crawlerStart": "https://threejs.org/docs/",  "crawlerPrefix": "https://threejs.org/docs/"}


### PR DESCRIPTION

Purpose: The change adds a new entry for Symfony documentation to the list of crawled documentation sources.

Symfony is a high-performance PHP framework widely adopted by enterprises and open-source projects, known for its reusable components, structured architecture, and strong developer community.

* [`docs.jsonl`](diffhunk://#diff-4e35511f08bafe2fd3e0e48468880ada1c90857268bc55065c0181725589d990R134): Added Symfony documentation with `crawlerStart` set to "https://symfony.com/doc/current/" and `crawlerPrefix` set to "https://symfony.com/doc/".

- [x] Ran the re-order script.
- [x] Ran the test script.