### PR TITLE
Add VueUse

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -143,6 +143,7 @@
 {  "name": "Vite",  "crawlerStart": "https://vitejs.dev/guide/",  "crawlerPrefix": "https://vitejs.dev/guide/"}
 {  "name": "Vitest",  "crawlerStart": "https://vitest.dev/guide/",  "crawlerPrefix": "https://vitest.dev/guide/"}
 {  "name": "Vue",  "crawlerStart": "https://vuejs.org/guide/introduction.html",  "crawlerPrefix": "https://vuejs.org/guide/"}
+{  "name": "VueUse",  "crawlerStart": "https://vueuse.org/guide/",  "crawlerPrefix": "https://vueuse.org/"}
 {  "name": "Webpack",  "crawlerStart": "https://webpack.js.org/concepts/",  "crawlerPrefix": "https://webpack.js.org/concepts/"}
 {  "name": "Zsh",  "crawlerStart": "https://zsh.sourceforge.io/Doc/",  "crawlerPrefix": "https://zsh.sourceforge.io/Doc/"}
 {  "name": "help",  "crawlerStart": "https://docs.cursor.com/get-started/welcome",  "crawlerPrefix": "https://docs.cursor.com/"}


### PR DESCRIPTION
[VueUse](https://vueuse.org/) is widely used in the Vue ecosystem (2M+ weekly [npm](https://www.npmjs.com/package/@vueuse/core) downloads) and provides essential composition utilities.

- [x] Ran the re-order script.
- [x] Ran the test script.