### PR TITLE
Add Alchemy Docs

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -5,6 +5,7 @@
 {  "name": "AWS ECS",  "crawlerStart": "https://docs.aws.amazon.com/ecs/",  "crawlerPrefix": "https://docs.aws.amazon.com/ecs/latest/developerguide/"}
 {  "name": "AWS Lambda",  "crawlerStart": "https://docs.aws.amazon.com/lambda/index.html",  "crawlerPrefix": "https://docs.aws.amazon.com/lambda/latest/dg/"}
 {  "name": "AWS RDS",  "crawlerStart": "https://docs.aws.amazon.com/rds/",  "crawlerPrefix": "https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/"}
+{  "name": "Alchemy",  "crawlerStart": "https://docs.alchemy.com/",  "crawlerPrefix": "https://docs.alchemy.com/"}
 {  "name": "Amazon EC2",  "crawlerStart": "https://docs.aws.amazon.com/ec2/index.html",  "crawlerPrefix": "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/"}
 {  "name": "Amazon S3",  "crawlerStart": "https://docs.aws.amazon.com/s3/index.html",  "crawlerPrefix": "https://docs.aws.amazon.com/AmazonS3/latest/userguide/"}
 {  "name": "Android SDK",  "crawlerStart": "https://developer.android.com/docs",  "crawlerPrefix": "https://developer.android.com/"}


### PR DESCRIPTION
The PR adds alchemy docs which is the most used platform to build onchain (Web3) applications contains guides, tutorials, api references.

The documentation meets all the required criteria for built-in docs as it is widely used, well-documented, developer-focused, and production-ready.