### PR TITLE
Add pytest - test framework for python

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -111,6 +111,7 @@
 {  "name": "Prisma",  "crawlerStart": "https://www.prisma.io/docs",  "crawlerPrefix": "https://www.prisma.io/docs"}
 {  "name": "Puppeteer",  "crawlerStart": "https://pptr.dev/",  "crawlerPrefix": "https://pptr.dev/"}
 {  "name": "PyTorch",  "crawlerStart": "https://pytorch.org/docs/stable/",  "crawlerPrefix": "https://pytorch.org/docs/stable/"}
+{  "name": "Pytest",  "crawlerStart": "https://docs.pytest.org/en/stable/",  "crawlerPrefix": "https://docs.pytest.org/en/stable/"}
 {  "name": "Python",  "crawlerStart": "https://docs.python.org/3/",  "crawlerPrefix": "https://docs.python.org/3/"}
 {  "name": "ROS",  "crawlerStart": "https://docs.ros.org/en/rolling/",  "crawlerPrefix": "https://docs.ros.org/en/rolling/"}
 {  "name": "Railway",  "crawlerStart": "https://docs.railway.app/",  "crawlerPrefix": "https://docs.railway.app/"}


### PR DESCRIPTION
# Changes

## Add `pytest` - test framework for python

See also:
- https://docs.pytest.org/en/stable/
- https://pypi.org/project/pytest
- https://github.com/pytest-dev/pytest'

# QA

- [x] Sort:

   ```
   crawler on  uv ❯ ./scripts/reorder.sh

   ✓ Successfully reordered 148 items
   ```
- [x] Test:

   ```
  ✓ https://docs.pytest.org/en/stable/ (200)
   ```