### PR TITLE
Add DuckDB as a Documentation Source

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -39,6 +39,7 @@
 {  "name": "Django Rest Framework",  "crawlerStart": "https://www.django-rest-framework.org/api-guide/requests/",  "crawlerPrefix": "https://www.django-rest-framework.org/api-guide"}
 {  "name": "Docker",  "crawlerStart": "https://docs.docker.com/",  "crawlerPrefix": "https://docs.docker.com/"}
 {  "name": "Drizzle",  "crawlerStart": "https://orm.drizzle.team/docs/overview",  "crawlerPrefix": "https://orm.drizzle.team/docs/overview"}
+{  "name": "DuckDB",  "crawlerStart": "https://duckdb.org/docs/sitemap",  "crawlerPrefix": "https://duckdb.org/docs/stable"}
 {  "name": "ELK Stack",  "crawlerStart": "https://www.elastic.co/guide/en/elastic-stack/current/index.html",  "crawlerPrefix": "https://www.elastic.co/guide/en/elastic-stack/current/"}
 {  "name": "ESBuild",  "crawlerStart": "https://esbuild.github.io/api/",  "crawlerPrefix": "https://esbuild.github.io/api/"}
 {  "name": "ESLint",  "crawlerStart": "https://eslint.org/docs/latest/",  "crawlerPrefix": "https://eslint.org/docs/latest/"}


### PR DESCRIPTION
# About DuckDB
[DuckDB](https://duckdb.org/) is an embeddable SQL OLAP database management system optimized for analytical queries. It's extremely fast, has no outside dependencies, SDKs for many popular programming languages, and a nice CLI.

# Why DuckDB
- It complements existing database-related packages in the docs list:
  - AWS DynamoDB
  - MongoDB
  - SQLite
- DuckDB works with many data science tools, including some already in the list:
  - Pandas
  - NumPy
  - Polars (sadly missing from current docs)
- DuckDB can directly query many other databases, data files, or data storage engines, including:
  - Postgres
  - SQLite
  - Parquet
  - JSONL
  - S3
  - etc.
- Open Source: https://github.com/duckdb/duckdb

---

1. **Widely Used**: DuckDB is commonly used and is especially gaining traction in the data science and analytics community.
2. **Well-Documented**: Offers detailed documentation with a stable URL structure and a sitemap.
3. **Developer-Focused**: Tailored for developers performing analytical tasks.
4. **Production-Ready**: Stable and reliable for real-world use.
5. **English Language**: Fully documented in English.
6. **Latest Versions**: DuckDB has a stable latest version, and the documentation is set up to easily browse the latest stable version.

## DuckDB Docs Benefit
I'd argue the ability to see the DuckDB-specific SQL syntax is the best benefit of adding the docs to Cursor. DuckDB's SQL syntax has [some powerful features](https://duckdb.org/docs/stable/sql/dialect/friendly_sql) that are not built into common OLTP databases like Postgres (the base of DuckDB's SQL style), MySQL, or SQLite.

Most LLMs miss the easy/correct ways to write basic analytics queries in DuckDB because they were trained on SQL syntax that looks more like Postgres. Adding the documentation would help users write DuckDB queries without leaving Cursor.

Read more about the DuckDB-specific SQL syntax here: https://duckdb.org/docs/stable/sql/dialect/overview