### PR TITLE
Add PromQL support to docs.jsonl

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -109,6 +109,7 @@
 {  "name": "PostgreSQL",  "crawlerStart": "https://www.postgresql.org/docs/current/",  "crawlerPrefix": "https://www.postgresql.org/docs/current/"}
 {  "name": "Postman",  "crawlerStart": "https://learning.postman.com/docs/",  "crawlerPrefix": "https://learning.postman.com/docs/"}
 {  "name": "Prisma",  "crawlerStart": "https://www.prisma.io/docs",  "crawlerPrefix": "https://www.prisma.io/docs"}
+{  "name": "PromQL", "crawlerStart": "https://prometheus.io/docs/prometheus/latest/", "crawlerPrefix": "https://prometheus.io/docs/prometheus/latest/"}
 {  "name": "Puppeteer",  "crawlerStart": "https://pptr.dev/",  "crawlerPrefix": "https://pptr.dev/"}
 {  "name": "PyTorch",  "crawlerStart": "https://pytorch.org/docs/stable/",  "crawlerPrefix": "https://pytorch.org/docs/stable/"}
 {  "name": "Python",  "crawlerStart": "https://docs.python.org/3/",  "crawlerPrefix": "https://docs.python.org/3/"}


### PR DESCRIPTION
We often use PromQL + Cursor to write queries. I've had cases where Cursor recommends `min(a, b)` but that function doesn't exist https://prometheus.io/docs/prometheus/latest/querying/functions/. I then tell Cursor off and it apologises by recommending `min(a,b)` again 😅 

📓 The last line was auto corrected by GitHub