### PR TITLE
Add Pydantic

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -110,6 +110,7 @@
 {  "name": "Postman",  "crawlerStart": "https://learning.postman.com/docs/",  "crawlerPrefix": "https://learning.postman.com/docs/"}
 {  "name": "Prisma",  "crawlerStart": "https://www.prisma.io/docs",  "crawlerPrefix": "https://www.prisma.io/docs"}
 {  "name": "Puppeteer",  "crawlerStart": "https://pptr.dev/",  "crawlerPrefix": "https://pptr.dev/"}
+{  "name": "Pydantic", "crawlerStart": "https://docs.pydantic.dev/latest/", "crawlerPrefix": "https://docs.pydantic.dev/latest/" }
 {  "name": "PyTorch",  "crawlerStart": "https://pytorch.org/docs/stable/",  "crawlerPrefix": "https://pytorch.org/docs/stable/"}
 {  "name": "Python",  "crawlerStart": "https://docs.python.org/3/",  "crawlerPrefix": "https://docs.python.org/3/"}
 {  "name": "ROS",  "crawlerStart": "https://docs.ros.org/en/rolling/",  "crawlerPrefix": "https://docs.ros.org/en/rolling/"}


### PR DESCRIPTION
As per https://forum.cursor.com/t/74216:

> I see that some Python libraries are already available as “official” documentation sources (numpy, pytest).
> 
> Would it be possible to add Pydantic as well? It is one of the most popular Python library, ranging at 300M downloads > monthly. You can reach us at [engineering@pydantic.dev](mailto:engineering@pydantic.dev) as well.
> 
> Thanks in advance,
> 
> Victorien.

Is there a way to test that it works as expected?