### PR TITLE
Add Groq to docs.jsonl

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -64,6 +64,7 @@
 {  "name": "Gradle",  "crawlerStart": "https://docs.gradle.org/current/userguide/userguide.html",  "crawlerPrefix": "https://docs.gradle.org/current/userguide/"}
 {  "name": "Grafana",  "crawlerStart": "https://grafana.com/docs/grafana/latest/",  "crawlerPrefix": "https://grafana.com/docs/grafana/latest/"}
 {  "name": "GraphQL",  "crawlerStart": "https://graphql.org/learn/",  "crawlerPrefix": "https://graphql.org/learn/"}
+{  "name": "Groq",  "crawlerStart": "https://console.groq.com/docs/overview",  "crawlerPrefix": "https://console.groq.com/docs"}
 {  "name": "HTML",  "crawlerStart": "https://developer.mozilla.org/en-US/docs/Web/HTML",  "crawlerPrefix": "https://developer.mozilla.org/en-US/docs/Web/HTML"}
 {  "name": "Heroku",  "crawlerStart": "https://devcenter.heroku.com/categories/reference",  "crawlerPrefix": "https://devcenter.heroku.com/"}
 {  "name": "Insomnia",  "crawlerStart": "https://docs.insomnia.rest/",  "crawlerPrefix": "https://docs.insomnia.rest/"}


### PR DESCRIPTION
Adds docs for [Groq API](https://console.groq.com/docs/overview) - high speed inference