### PR TITLE
Add ArgoCD documentation entry to docs.jsonl

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -14,6 +14,7 @@
 {  "name": "Apache Airflow",  "crawlerStart": "https://airflow.apache.org/docs/apache-airflow/stable/index.html",  "crawlerPrefix": "https://airflow.apache.org/docs/apache-airflow/stable/"}
 {  "name": "Apollo GraphQL",  "crawlerStart": "https://www.apollographql.com/docs/",  "crawlerPrefix": "https://www.apollographql.com/docs/"}
 {  "name": "Apple Developer Documention",  "crawlerStart": "https://developer.apple.com/documentation/",  "crawlerPrefix": "https://developer.apple.com/documentation/"}
+{  "name": "ArgoCD",  "crawlerStart": "https://argo-cd.readthedocs.io/en/stable/",  "crawlerPrefix": "https://argo-cd.readthedocs.io/en/stable/"}
 {  "name": "Astro",  "crawlerStart": "https://docs.astro.build/en/",  "crawlerPrefix": "https://docs.astro.build/en/"}
 {  "name": "Auth0",  "crawlerStart": "https://auth0.com/docs",  "crawlerPrefix": "https://auth0.com/docs"}
 {  "name": "Azure Pipelines",  "crawlerStart": "https://docs.microsoft.com/en-us/azure/devops/pipelines/?view=azure-devops",  "crawlerPrefix": "https://docs.microsoft.com/en-us/azure/devops/pipelines/"}


### PR DESCRIPTION
Adds docs for [ArgoCD](https://argo-cd.readthedocs.io/en/stable/) -  a declarative, GitOps continuous delivery tool for Kubernetes.