### PR TITLE
Add official PubNub docs

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -23,7 +23,7 @@
 {  "name": "Bun",  "crawlerStart": "https://bun.sh/docs",  "crawlerPrefix": "https://bun.sh/docs"}
 {  "name": "C#",  "crawlerStart": "https://learn.microsoft.com/en-us/dotnet/csharp/",  "crawlerPrefix": "https://learn.microsoft.com/en-us/dotnet/csharp/"}
 {  "name": "CSS",  "crawlerStart": "https://developer.mozilla.org/en-US/docs/Web/CSS",  "crawlerPrefix": "https://developer.mozilla.org/en-US/docs/Web/CSS"}
-{  "name": "CUDA",  "crawlerStart": "https://docs.nvidia.com/cuda/index.html", "crawlerPrefix":  "https://docs.nvidia.com/cuda/"}
+{  "name": "CUDA",  "crawlerStart": "https://docs.nvidia.com/cuda/index.html",  "crawlerPrefix": "https://docs.nvidia.com/cuda/"}
 {  "name": "Cheerio",  "crawlerStart": "https://cheerio.js.org/docs/intro",  "crawlerPrefix": "https://cheerio.js.org/docs/"}
 {  "name": "CircleCI",  "crawlerStart": "https://circleci.com/docs/",  "crawlerPrefix": "https://circleci.com/docs/"}
 {  "name": "Clerk",  "crawlerStart": "https://clerk.com/docs",  "crawlerPrefix": "https://clerk.com/docs"}
@@ -49,9 +49,9 @@
 {  "name": "Emacs",  "crawlerStart": "https://www.gnu.org/software/emacs/manual/html_node/emacs/",  "crawlerPrefix": "https://www.gnu.org/software/emacs/manual/html_node/emacs/"}
 {  "name": "Expo",  "crawlerStart": "https://docs.expo.dev/",  "crawlerPrefix": "https://docs.expo.dev/"}
 {  "name": "Express",  "crawlerStart": "https://expressjs.com/en/5x/api.html",  "crawlerPrefix": "https://expressjs.com/en/5x/"}
-{  "name": "Fal.ai",  "crawlerStart": "https://docs.fal.ai/quick-start",  "crawlerPrefix": "https://docs.fal.ai/"}
 {  "name": "FFmpeg",  "crawlerStart": "https://ffmpeg.org/ffmpeg.html",  "crawlerPrefix": "https://ffmpeg.org/ffmpeg.html"}
 {  "name": "Fabric.js",  "crawlerStart": "http://fabricjs.com/docs/",  "crawlerPrefix": "http://fabricjs.com/docs/"}
+{  "name": "Fal.ai",  "crawlerStart": "https://docs.fal.ai/quick-start",  "crawlerPrefix": "https://docs.fal.ai/"}
 {  "name": "FastAPI",  "crawlerStart": "https://fastapi.tiangolo.com/tutorial/",  "crawlerPrefix": "https://fastapi.tiangolo.com/tutorial/"}
 {  "name": "Firebase",  "crawlerStart": "https://firebase.google.com/docs",  "crawlerPrefix": "https://firebase.google.com/docs"}
 {  "name": "Flask",  "crawlerStart": "https://flask.palletsprojects.com/en/2.3.x/",  "crawlerPrefix": "https://flask.palletsprojects.com/en/2.3.x/"}
@@ -114,15 +114,16 @@
 {  "name": "Pinia",  "crawlerStart": "https://pinia.vuejs.org/core-concepts/",  "crawlerPrefix": "https://pinia.vuejs.org/"}
 {  "name": "Playwright",  "crawlerStart": "https://playwright.dev/docs/intro",  "crawlerPrefix": "https://playwright.dev/docs/"}
 {  "name": "Pnpm",  "crawlerStart": "https://pnpm.io/",  "crawlerPrefix": "https://pnpm.io/"}
-{  "name": "Polars",  "crawlerStart": "https://docs.pola.rs/",  "crawlerPrefix": "https://docs.pola.rs/"}
 {  "name": "Polaris",  "crawlerStart": "https://polaris.shopify.com/",  "crawlerPrefix": "https://polaris.shopify.com/"}
+{  "name": "Polars",  "crawlerStart": "https://docs.pola.rs/",  "crawlerPrefix": "https://docs.pola.rs/"}
 {  "name": "PostgreSQL",  "crawlerStart": "https://www.postgresql.org/docs/current/",  "crawlerPrefix": "https://www.postgresql.org/docs/current/"}
 {  "name": "Postman",  "crawlerStart": "https://learning.postman.com/docs/",  "crawlerPrefix": "https://learning.postman.com/docs/"}
 {  "name": "Prisma",  "crawlerStart": "https://www.prisma.io/docs",  "crawlerPrefix": "https://www.prisma.io/docs"}
+{  "name": "PubNub",  "crawlerStart": "https://www.pubnub.com/docs",  "crawlerPrefix": "https://www.pubnub.com/docs"}
 {  "name": "Pulumi",  "crawlerStart": "https://www.pulumi.com/docs/",  "crawlerPrefix": "https://www.pulumi.com/docs/"}
 {  "name": "Puppeteer",  "crawlerStart": "https://pptr.dev/",  "crawlerPrefix": "https://pptr.dev/"}
-{  "name": "Pydantic", "crawlerStart": "https://docs.pydantic.dev/latest/", "crawlerPrefix": "https://docs.pydantic.dev/latest/" }
 {  "name": "PyTorch",  "crawlerStart": "https://pytorch.org/docs/stable/",  "crawlerPrefix": "https://pytorch.org/docs/stable/"}
+{  "name": "Pydantic",  "crawlerStart": "https://docs.pydantic.dev/latest/",  "crawlerPrefix": "https://docs.pydantic.dev/latest/"}
 {  "name": "Pytest",  "crawlerStart": "https://docs.pytest.org/en/stable/",  "crawlerPrefix": "https://docs.pytest.org/en/stable/"}
 {  "name": "Python",  "crawlerStart": "https://docs.python.org/3/",  "crawlerPrefix": "https://docs.python.org/3/"}
 {  "name": "ROS",  "crawlerStart": "https://docs.ros.org/en/rolling/",  "crawlerPrefix": "https://docs.ros.org/en/rolling/"}


### PR DESCRIPTION
I added the official [PubNub](https://www.pubnub.com/docs) documentation to the crawler because the docs available using the @Docs directive in Cursor are outdated.

I ran the reorder script.

![image](https://github.com/user-attachments/assets/959c1e9d-0db5-4cb1-b710-586f5f27c844)
