### PR TITLE
Add Hugging Face Transformers

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -70,6 +70,7 @@
 {  "name": "HTML",  "crawlerStart": "https://developer.mozilla.org/en-US/docs/Web/HTML",  "crawlerPrefix": "https://developer.mozilla.org/en-US/docs/Web/HTML"}
 {  "name": "Heroku",  "crawlerStart": "https://devcenter.heroku.com/categories/reference",  "crawlerPrefix": "https://devcenter.heroku.com/"}
 {  "name": "Hono",  "crawlerStart": "https://hono.dev/docs/",  "crawlerPrefix": "https://hono.dev/docs/"}
+{  "name": "Hugging Face Transformers",  "crawlerStart": "https://huggingface.co/docs/transformers/index",  "crawlerPrefix": "https://huggingface.co/docs/transformers/"}
 {  "name": "Insomnia",  "crawlerStart": "https://docs.insomnia.rest/",  "crawlerPrefix": "https://docs.insomnia.rest/"}
 {  "name": "Ionic",  "crawlerStart": "https://ionicframework.com/docs",  "crawlerPrefix": "https://ionicframework.com/docs"}
 {  "name": "JAX",  "crawlerStart": "https://jax.readthedocs.io/en/latest/",  "crawlerPrefix": "https://jax.readthedocs.io/"}


### PR DESCRIPTION
This PR adds the official Hugging Face Transformers documentation.

`{  "name": "Hugging Face Transformers",  "crawlerStart": "https://huggingface.co/docs/transformers/index",  "crawlerPrefix": "https://huggingface.co/docs/transformers/"}`

- [x] Ran reorder.sh
- [x] Ran test.sh and received a 200 for both https://huggingface.co/docs/transformers/ and https://huggingface.co/docs/transformers/index

This meets all criteria:

- Widely Used: Adopted globally across academia and industry for state-of-the-art NLP, vision, and multimodal applications.
- Well-Documented: Official docs include guides, tutorials, and API reference, maintained in English.
- Developer-Focused: Provides clear instructions and examples for Python, PyTorch, TensorFlow, and JAX.
- Production-Ready: Powers mission-critical pipelines and research at scale.
- English Language: Documentation is entirely in English.
- Latest Versions: Always reflects the latest stable release at