### PR TITLE
Adds Prefect 3 documentation (https://docs.prefect.io/v3/) as a built-in source.

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -118,6 +118,7 @@
 {  "name": "Polars",  "crawlerStart": "https://docs.pola.rs/",  "crawlerPrefix": "https://docs.pola.rs/"}
 {  "name": "PostgreSQL",  "crawlerStart": "https://www.postgresql.org/docs/current/",  "crawlerPrefix": "https://www.postgresql.org/docs/current/"}
 {  "name": "Postman",  "crawlerStart": "https://learning.postman.com/docs/",  "crawlerPrefix": "https://learning.postman.com/docs/"}
+{  "name": "Prefect",  "crawlerStart": "https://docs.prefect.io/v3/get-started",  "crawlerPrefix": "https://docs.prefect.io/v3/"}
 {  "name": "Prisma",  "crawlerStart": "https://www.prisma.io/docs",  "crawlerPrefix": "https://www.prisma.io/docs"}
 {  "name": "Pulumi",  "crawlerStart": "https://www.pulumi.com/docs/",  "crawlerPrefix": "https://www.pulumi.com/docs/"}
 {  "name": "Puppeteer",  "crawlerStart": "https://pptr.dev/",  "crawlerPrefix": "https://pptr.dev/"}


### PR DESCRIPTION
#### ✨ What’s inside

* **`docs.jsonl`** – one new entry:

  ```json
  { "name": "Prefect", "crawlerStart": "https://docs.prefect.io/v3/get-started", "crawlerPrefix": "https://docs.prefect.io/v3/" }
  ```
* Ran **`./scripts/reorder.sh`** to alphabetize and de-dupe the list; diff is minimal and neatly sorted.

---

#### 🤔 Why Prefect?

* Developer Relevance: Widely-adopted Python orchestration framework
* Stable URL structure: All v3 docs live under a single /v3/ prefix, preventing crawler bleed-over into legacy content
* High search value: Frequent target for workflow/ETL questions; having built-in docs removes context-switching for users.

---

#### ✅ Pre-merge checklist

* Added a single JSONL object with correct start & prefix URLs
* Executed `scripts/reorder.sh` successfully (no duplicate keys / format issues)